### PR TITLE
BACKEND-6: Make logging more efficient

### DIFF
--- a/.github/workflows/build-sonar.yml
+++ b/.github/workflows/build-sonar.yml
@@ -36,4 +36,5 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           cd services
-          ./gradlew build sonar --stacktrace
+          ./gradlew build --stacktrace
+          ./gradlew sonar --info


### PR DESCRIPTION
BACKEND-6: As I am working on my diploma task right now I noticed that we get a lot of useless info when running build with the --info arg, but when we run sonar with the --info arg it can give good logs. So I changed up the build-sonar.yaml to execute build with only the --stacktrace oprion since we don't expect any problems there and to execute sonar task with --info option as we might actually want to read these.